### PR TITLE
Allow `chkpt_stan()` to work on Mac/linux

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: chkptstanr
 Title: Checkpoint MCMC Sampling with 'Stan'
-Version: 0.1.1
+Version: 0.1.1.9000
 Date: 2022-04-27
 Authors@R: c(
   person(given = "Donald", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# chkptstanr (development version)
+
 # Version 0.1.1
 
 ## Bug fixes and minor improvements

--- a/R/chkpt_stan.R
+++ b/R/chkpt_stan.R
@@ -168,7 +168,11 @@ chkpt_stan <- function(model_code,
     
   }
   
-  if (isFALSE(check_for_model("model_threads.exe", path))) {
+  model_threads_name <- ifelse(.Platform$OS.type == "unix", 
+                               "model", 
+                               "model_threads.exe")
+
+  if (isFALSE(check_for_model(eval(model_threads_name), path))) {
     
     stan_m3 <- cmdstanr::cmdstan_model(stan_file = stan_code_path,
                              cpp_options = list(stan_threads = TRUE))


### PR DESCRIPTION
See #5, and related to #3. I used similar logic to https://github.com/donaldRwilliams/chkptstanr/commit/959e7fbb274c98807af26a1c5d26a8cc6d5e38c8 for this fix, but it might need to be applied to other files as well. 