### PR TITLE
Updates to `chkpt_stan` to allow for loading existing models and combining checkpoint draws

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Suggests:
     posterior
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Additional_repositories: 
   https://mc-stan.org/r-packages/
 RdMacros: Rdpack

--- a/R/chkpt_stan.R
+++ b/R/chkpt_stan.R
@@ -165,7 +165,9 @@ chkpt_stan <- function(model_code,
       dir = paste0(path, "/stan_model"),
       basename = "model"
     )
-    
+
+  } else {
+    stan_code_path <- paste0(path, "/stan_model/model.stan")
   }
   
   model_threads_name <- ifelse(.Platform$OS.type == "unix", 
@@ -241,7 +243,10 @@ chkpt_stan <- function(model_code,
   
   if (last_chkpt == total_chkpts) {
     
-    return(message("Checkpointing complete"))
+    message("Checkpointing complete")
+    returned_object <- list(args = args)
+    class(returned_object) <- "chkpt_stan"
+    return(returned_object)
     
     
   } else {


### PR DESCRIPTION
The `chkpt_stan()` function now handles (1) loading existing models and (2) combining checkpoint draws for models that have finished completely. This functionality was not fully implemented for `cmdstanr` models in the previous version.